### PR TITLE
Adding option to skip backup on copy

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,3 +8,7 @@ kernel_cmdline: []
 kernel_cmdline_remove: []
 
 kernel_restart_handler: reboot
+
+# optionally skip backing up the config file. Can cause issues on some
+# filesystems due to filenames containing illegal characters
+backup_grub_config_file: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -51,7 +51,7 @@
     path: /etc/default/grub
     regexp: '^GRUB_CMDLINE_LINUX_DEFAULT'
     line: GRUB_CMDLINE_LINUX_DEFAULT="{{ grub_cmdline_linux_new | join(' ') }}"
-    backup: true
+    backup: "{{ backup_grub_config_file }}"
   become: true
 
 - name: Generate new grub-config
@@ -62,7 +62,7 @@
 
 - name: replace current grub config
   copy:
-    backup: true
+    backup: "{{ backup_grub_config_file }}"
     # /etc/grub2.cfg -> ../boot/grub2/grub.cfg
     follow: true
     content: "{{ grub_mkconfig_result.stdout }}"


### PR DESCRIPTION
The backup function can cause issues on some filesystems as it can add illegal characters and therefore fail. This patch makes the operation optional.